### PR TITLE
fix the warning in AlertIOS.alert

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -114,8 +114,7 @@ class FirebaseReactNativeSample extends Component {
         [
           {text: 'Complete', onPress: (text) => this.itemsRef.child(item._key).remove()},
           {text: 'Cancel', onPress: (text) => console.log('Cancelled')}
-        ],
-        'default'
+        ]
       );
     };
 


### PR DESCRIPTION
it shows when trying to complete a task in App:

![screen shot 2016-08-08 at 7 27 11 pm](https://cloud.githubusercontent.com/assets/39830/17477147/7e23c5c8-5d9e-11e6-8e8c-aa8b46f55412.png)

> 'AlertIOS.alert() with a 4th "type" parameter is deprecated and will be removed. Use AlertIOS.prompt() instead.'
